### PR TITLE
WIP: Add filter / ido_filter and improve get_matches performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cd ~/.config/nvim/pack/plugins/start && git clone https://github.com/shoumodip/i
 ***NOTE:*** All the documentation shown from now on is in lua. Dont' attempt to do this stuff in VimL.
 
 ## How to use
-Ido is invoked using `ido_completing_read({OPTIONS})` which takes a table as an input. The table `OPTIONS` can contain four items / subtables --
+Ido is invoked using `ido_completing_read({OPTIONS})` which takes a table as an input. The table `OPTIONS` can contain five items / subtables --
 
 `prompt` The prompt to be used. If left blank, then `ido_default_prompt` will be used.
 
@@ -43,6 +43,8 @@ Ido is invoked using `ido_completing_read({OPTIONS})` which takes a table as an 
 `keybinds` Custom keybindings to be used. If left default, then `ido_keybindings` will be used.
 
 `on_enter` The function which will be executed on returning the value.
+
+`filter' The function which will be executed to filter the items list
 
 For example.
 
@@ -81,6 +83,57 @@ Most probably, Ido will look horrible on your terminal. The reason being Ido use
 
 `IdoPrompt` The color used for the prompt.
 
+## Filters
+Ido.nvim comes with a default fuzzy filter function that should serve most common use-cases.
+If more flexibility is desired, ido provides two mechanisms to define custom filters:
+
+### 1. `filter` option for ido_complete function
+You can pass a `filter` option when invoking `ido_complete`. This function when present will receive the following arguments:
+
+`ido_match_list` The list of items on which the pattern is being matched.
+
+`ido_pattern_text` The pattern being matched in the items.
+
+`ido_matched_items` The table of the items matched.
+
+`ido_true_matched_items` The table of the items that are exact matches.
+
+Ido expects the filter function to `reduce` the `ido_match_list` by inserting all `exact matches` in the `ido_true_matched_items` array and all other matches in `ido_matched_items`
+
+```lua
+ido_complete({
+  items = {'red', 'green', 'blue'},
+  filter = function(items, s, matches, exact_matches)
+    for k,v in pairs(items) do
+      if v:match('^' .. s) then
+        table.insert(exact_matches, v)
+      elseif v:match(s) then
+        table.insert(matches, v)
+      end
+    end
+  end
+})
+```
+
+### 2. global `ido_filter` setting
+When specified this function will be used by all `ido_complete` functions that dont have an explicit custom filter.
+Function receives same arguments as the aforementioned `filter` option.
+
+```lua
+ido_filter = function(items, s, matches, exact_matches)
+  for k,v in pairs(items) do
+    if v:match('^' .. s) then
+      table.insert(exact_matches, v)
+    elseif v:match(s) then
+      table.insert(matches, v)
+    end
+  end
+end
+
+-- This ido_complete will defer to the global `ido_filter` function
+ido_complete({ items = {'red', 'green', 'blue'})
+```
+
 ## Settings
 `ido_fuzzy_matching` (**Boolean**) Whether Ido should match fuzzily or not. Set to `true` by default.
 
@@ -93,6 +146,8 @@ Most probably, Ido will look horrible on your terminal. The reason being Ido use
 `ido_max_lines` (**Number**) The maximum boundary of the Ido minibuffer. Only has any effect if `ido_limit_lines` is `false`.
 
 `ido_limit_lines` (**Boolean**) If the number of lines in the Ido minibuffer exceeds `ido_min_lines`, decides whether to show the `more_items` symbol or make the minibuffer `ido_max_lines` tall. `true` by default.
+
+`ido_filter` (**Function**) If set Ido will defer to this filter function on all `ido_complete` invocations, unless a `ido_complete` specifies a local `filter` option.
 
 `ido_minimal_mode` (**Boolean**) If set to `true`, Ido will be rendered in command mode (`:`), and the `ido_{min, max, limit}_lines` will have no effect. If set to `false`, Ido will be rendered in a floating window, and the afforementioned variables will have effect if needed. `false` by default.
 

--- a/lua/ido.lua
+++ b/lua/ido.lua
@@ -53,6 +53,19 @@ ido_decorations = {
 ido_max_lines = 10
 ido_min_lines = 3
 ido_key_bindings = {}
+ido_filter = function(items, pattern, matches, exact_matches)
+  for k,v in pairs(items) do
+    if not ido_case_sensitive then
+      v = v:lower()
+    end
+
+    if v:match('^' .. pattern) then
+      table.insert(exact_matches, v)
+    elseif v:match(pattern) then
+      table.insert(matches, v)
+    end
+  end
+end
 -- }}}
 -- Special keys -{{{
 local ido_hotkeys = {}
@@ -153,34 +166,20 @@ function ido_get_matches(filter_func)
 
   -- Decide what filter to use, prioritizes `local' user provided `opts:filter`
   -- over global `ido_filter`
-  -- falls back to default filter function if both are undefined
   if filter_func then
     filter_func(
       ido_match_list,
       ido_pattern_text,
-      ido_true_matched_items,
-      ido_matched_items
+      ido_matched_items,
+      ido_true_matched_items
     )
-  elseif ido_filter then
+  else
     ido_filter(
       ido_match_list,
       ido_pattern_text,
-      ido_true_matched_items,
-      ido_matched_items
+      ido_matched_items,
+      ido_true_matched_items
     )
-  else
-    for k,v in pairs(ido_match_list) do
-      if not ido_case_sensitive then
-        v = v:lower()
-      end
-
-      -- Determine if this is a true match or a regular match
-      if v:match('^' .. ido_pattern_text) then
-        table.insert(ido_true_matched_items, v)
-      elseif v:match(ido_pattern_text) then
-        table.insert(ido_matched_items, v)
-      end
-    end
   end
 
   if #ido_matched_items > 1 or #ido_true_matched_items > 1 then


### PR DESCRIPTION
close #8 

This PR makes the following improvements:

1. only loop through `ido_match_list` once to fill the `ido_matched_items` and `ido_true_matched_items` significantly improving performance for big lists
2. Add the option for users to provide their own `filter` function both as an `option` in the `ido_complete` function as well as a global `ido_filter` setting that allows providing a global override. `ido_filter` defaults to the current filter behavior.

Future improvements worth exploring but excluded from this PR:

- Splitting up the `get_matches` function currently it has too many responsibilities:
  - Filtering the `ido_match_list` 
  - Determining the prefix 
- Removing the need to extract both a `exact matches` collection and `matches` collection by refactoring the `prefix` calculation method.
- Improving the performance of determining the prefix (and/or making this configurable as well)