### PR TITLE
Add pkg_opts to `pkg.setup`, `pkg.new`, and `pkg.run`

### DIFF
--- a/lua/ido.lua
+++ b/lua/ido.lua
@@ -426,8 +426,10 @@ end
 
 --- Run a package
 -- @param name The name of the package
+-- @param pkg_opts Table with options passed to the package's main function
 -- @return exit value of the package
-function ido.pkg.run(name)
+function ido.pkg.run(name, pkg_opts)
+   pkg_opts = pkg_opts or {}
 
    -- Check the type of the name
    if type(name) ~= "string" then
@@ -442,7 +444,7 @@ function ido.pkg.run(name)
    end
 
    ido.pkg.running = name
-   return ido.pkg.list[name].main(ido.pkg.list[name].pkg_opts)
+   return ido.pkg.list[name].main(vim.tbl_extend("force", pkg_opts, ido.pkg.list[name].pkg_opts))
 end
 
 --- Syntactic sugar over ido.start()

--- a/lua/ido.lua
+++ b/lua/ido.lua
@@ -210,9 +210,10 @@ ido.pkg = {
    -- A package template
    template = {
       opts = {},
+      pkg_opts = {},
       bind = {},
       disable = {},
-      main = function () end,
+      main = function (pkg_opts) end,
    },
 
    -- A package keybinding template
@@ -405,8 +406,9 @@ function ido.pkg.setup(name, opts)
       elseif opt == "bind" then
          value = vim.tbl_extend("keep", value, ido.pkg.list[name].bind)
 
+      elseif opt == "pkg_opts" then
+         value = vim.tbl_extend("keep", value, ido.pkg.list[name].pkg_opts)
       else
-
          error("Invalid option: "..opt, 2)
          return nil
       end
@@ -440,7 +442,7 @@ function ido.pkg.run(name)
    end
 
    ido.pkg.running = name
-   return ido.pkg.list[name].main()
+   return ido.pkg.list[name].main(ido.pkg.list[name].pkg_opts)
 end
 
 --- Syntactic sugar over ido.start()

--- a/wiki/packages.md
+++ b/wiki/packages.md
@@ -43,10 +43,11 @@ Configure an existing package. It will change the options related to the package
 
 If a package with that name does not exist, it will throw an error.
 
-## `pkg.run(NAME)`
+## `pkg.run(NAME, PKG_OPTS)`
 Run a package. Basically it runs the `main` function defined in the package. It passes the `pkg_opts` as a function argument to the main function when specified.
 
 - `name` The name of the package
+- `pkg_opts` Runtime overrides for the `pkg_opts` specified during `pkg.setup()` and `pkg.new()`. See [Package structure](#package-structure) above.
 
 ## `pkg.start(OPTS)`
 Syntactic sugar over the `ido.start()` function. Use this when creating a package instead of `ido.start()`


### PR DESCRIPTION
As described in https://github.com/ido-nvim/core/issues/20, https://github.com/ido-nvim/files/issues/3, and https://github.com/ido-nvim/git/issues/2

One key missing part of the `package` api (which would make it feature complete imo) is the option for users to pass a configuration table to a ido package both on setup as well as at runtime.

This PR implements this by adding a new `pkg_opts` key in the existing `OPTS` hashes used in `pkg.setup`, and `pkg.new` as well as adding a second optional argument to `pkg.run`.

The main entry point of packages will receive the `pkg_opts` that is specified during `pkg.setup` or `pkg.run` and can consume it to for instance override the command used the retrieve its items, or any other use-case really.

Code speaks louder than words so to see the `pkg_opts` and the power it provides, check out the `pkg_opts`  branch of `ido-git` repo for an example: https://github.com/ido-nvim/git/tree/pkg_opts